### PR TITLE
Stabilize assistant text chat test and active sorting

### DIFF
--- a/detective-board/tests/active-sorting.spec.ts
+++ b/detective-board/tests/active-sorting.spec.ts
@@ -24,6 +24,13 @@ test.describe('Active page sorting', () => {
   test('dates are strictly ascending by day', async ({ page }) => {
     await resetAndSeed(page);
     await page.goto('/active');
+    await page.waitForFunction(() => {
+      const store = (globalThis as any).__appStore;
+      if (!store?.getState) return false;
+      const nodes = store.getState().nodes;
+      return Array.isArray(nodes) && nodes.filter((n: any) => n?.type === 'task').length >= 3;
+    }, { timeout: 10_000 });
+    await page.waitForFunction(() => document.querySelectorAll('[data-testid="date-header"]').length >= 3, { timeout: 5_000 });
     const headers = page.locator('[data-testid="date-header"]');
     const count = await headers.count();
     expect(count).toBeGreaterThanOrEqual(3);


### PR DESCRIPTION
## Summary
- stub the assistant text-mode Playwright scenario to feed deterministic Responses API data and assert the transcript & status
- wait for seeded tasks and headers before asserting active list order so the sort test passes reliably across browsers

## Testing
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68cfb29614b0832092c165b11345f8f0