### PR TITLE
feat: default text assistant to Google Gemini

### DIFF
--- a/detective-board/.env.example
+++ b/detective-board/.env.example
@@ -1,4 +1,4 @@
-# Copy this file to .env.local and fill in your Google Custom Search credentials
+# Copy this file to .env.local and fill in your API credentials
 # Vite will expose variables starting with VITE_ to the client.
 
 # API key for Google Custom Search API
@@ -6,6 +6,13 @@ VITE_GOOGLE_CSE_KEY=
 
 # Custom Search Engine ID (CX)
 VITE_GOOGLE_CSE_CX=
+
+# Google Gemini (server-side, used by Vite dev middleware for /api/google/text)
+GOOGLE_API_KEY=
+
+# Text chat model for /api/google/text (server-side)
+# Example values: gemini-1.5-flash-latest (default)
+GOOGLE_TEXT_MODEL=
 
 # OpenAI API key (server-side, used by Vite dev middleware for Realtime ephemeral tokens)
 OPENAI_API_KEY=

--- a/detective-board/README.md
+++ b/detective-board/README.md
@@ -80,3 +80,6 @@ export default tseslint.config([
   },
 ])
 ```
+
+
+ИИ-ассистент пока не работает

--- a/detective-board/README.md
+++ b/detective-board/README.md
@@ -1,5 +1,18 @@
 # React + TypeScript + Vite
 
+## Assistant configuration
+
+The built-in assistant supports Google Gemini (default for текстовый чат) and OpenAI. Configure the following environment variables before starting the dev server:
+
+- `GOOGLE_API_KEY` — ключ доступа к Google Generative Language API (Gemini).
+- `GOOGLE_TEXT_MODEL` *(опционально)* — идентификатор модели Gemini для текстового чата (по умолчанию `gemini-1.5-flash-latest`).
+- `OPENAI_API_KEY` — ключ OpenAI, используется для голосового режима и текстового чата при выборе OpenAI.
+- `OPENAI_TEXT_MODEL` *(опционально)* — модель OpenAI для текстового режима (по умолчанию `gpt-4o-mini`).
+
+Секретные ключи не коммитим в репозиторий. Поместите их, например, в `.env.local`.
+
+---
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:

--- a/detective-board/vite.config.ts
+++ b/detective-board/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const OPENAI_API_KEY = env.OPENAI_API_KEY;
+  const GOOGLE_API_KEY = env.GOOGLE_API_KEY;
   const TELEGRAM_BOT_TOKEN = env.TELEGRAM_BOT_TOKEN;
 
   return {
@@ -37,7 +38,94 @@ export default defineConfig(({ mode }) => {
             }
           });
 
-        // Text completion endpoint (dev-only) to avoid WebRTC for text mode
+        // Text completion endpoint (Google Gemini)
+        server.middlewares.use('/api/google/text', async (req, res) => {
+          if (req.method !== 'POST') { res.statusCode = 405; res.end('Method Not Allowed'); return; }
+          try {
+            const chunks: Uint8Array[] = [];
+            req.on('data', (c: Uint8Array) => chunks.push(c));
+            await new Promise<void>((resolve) => req.on('end', () => resolve()));
+            const bodyStr = Buffer.concat(chunks).toString('utf8');
+            const body = bodyStr ? JSON.parse(bodyStr) as { message?: string; instructions?: string; context?: string } : {};
+            const message = (body.message || '').slice(0, 4000);
+            const instructions = (body.instructions || '').slice(0, 8000);
+            const context = (body.context || '').slice(0, 16000);
+            const sys = instructions || 'Ты ассистент и отвечаешь кратко и по делу на русском.';
+            const user = context ? `${message}\n\nКОНТЕКСТ:\n${context}` : message;
+            const textModel = (env.GOOGLE_TEXT_MODEL || 'gemini-1.5-flash-latest');
+
+            if (message && message.startsWith('[TEST_SAVE_JSON]')) {
+              const text = [
+                'Ассистент: Обновляю сохранённую информацию согласно вашему запросу.',
+                'SAVE_JSON: { "about_me": "Родился в Грозном. Гражданство России. Жена и дети — украинцы.", "environment": "Черногория, город Бар" }'
+              ].join('\n');
+              res.statusCode = 200;
+              res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify({ text, model: textModel, stub: true }));
+              return;
+            }
+
+            const apiKey = GOOGLE_API_KEY;
+            if (!apiKey) {
+              res.statusCode = 500; res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify({ error: 'GOOGLE_API_KEY is not set on server' }));
+              return;
+            }
+
+            const payload: {
+              contents: Array<{ role: string; parts: Array<{ text: string }> }>;
+              systemInstruction?: { role: string; parts: Array<{ text: string }> };
+              safetySettings?: Array<{ category: string; threshold: string }>;
+              generationConfig: { temperature: number };
+            } = {
+              contents: [
+                { role: 'user', parts: [{ text: user }] },
+              ],
+              generationConfig: { temperature: 0.3 },
+            };
+            if (sys) {
+              payload.systemInstruction = { role: 'system', parts: [{ text: sys }] };
+            }
+            payload.safetySettings = [
+              { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+              { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+              { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+              { category: 'HARM_CATEGORY_SEXUAL', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+            ];
+
+            const url = `https://generativelanguage.googleapis.com/v1beta/models/${textModel}:generateContent?key=${apiKey}`;
+            const resp = await fetch(url, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+            type GeminiContentPart = { text?: string };
+            type GeminiCandidate = { content?: { parts?: GeminiContentPart[] }; text?: string };
+            type GeminiResponse = { candidates?: GeminiCandidate[]; error?: { message?: string } };
+            const json = await resp.json() as GeminiResponse;
+            if (!resp.ok) {
+              throw new Error(json?.error?.message || 'Google response not OK');
+            }
+            let text = '';
+            const candidate = json?.candidates?.[0];
+            const parts = candidate?.content?.parts;
+            if (Array.isArray(parts)) {
+              text = parts.map((part) => (part?.text ?? '')).join('').trim();
+            }
+            if (!text && candidate?.text) {
+              text = candidate.text;
+            }
+            res.statusCode = resp.status;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ text, model: textModel }));
+          } catch (e) {
+            console.error('/api/google/text error', e);
+            res.statusCode = 500; res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ error: 'google_text_failed' }));
+          }
+        });
+
+        // Text completion endpoint (OpenAI, fallback)
         server.middlewares.use('/api/openai/text', async (req, res) => {
           if (req.method !== 'POST') { res.statusCode = 405; res.end('Method Not Allowed'); return; }
           try {

--- a/detective-board/vite.config.ts
+++ b/detective-board/vite.config.ts
@@ -129,12 +129,7 @@ export default defineConfig(({ mode }) => {
         server.middlewares.use('/api/openai/text', async (req, res) => {
           if (req.method !== 'POST') { res.statusCode = 405; res.end('Method Not Allowed'); return; }
           try {
-            const apiKey = OPENAI_API_KEY;
-            if (!apiKey) {
-              res.statusCode = 500; res.setHeader('Content-Type', 'application/json');
-              res.end(JSON.stringify({ error: 'OPENAI_API_KEY is not set on server' }));
-              return;
-            }
+            // Read body first to support local test stubs without requiring API key
             const chunks: Uint8Array[] = [];
             req.on('data', (c: Uint8Array) => chunks.push(c));
             await new Promise<void>((resolve) => req.on('end', () => resolve()));
@@ -156,6 +151,13 @@ export default defineConfig(({ mode }) => {
               res.statusCode = 200;
               res.setHeader('Content-Type', 'application/json');
               res.end(JSON.stringify({ text, model: textModel, stub: true }));
+              return;
+            }
+
+            const apiKey = OPENAI_API_KEY;
+            if (!apiKey) {
+              res.statusCode = 500; res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify({ error: 'OPENAI_API_KEY is not set on server' }));
               return;
             }
 


### PR DESCRIPTION
## Summary
- add provider selector to the assistant modal and persist Google as the default text chat backend
- implement a dev text endpoint for Google Gemini while keeping the existing OpenAI fallback
- document the required environment variables for Google and OpenAI assistants

## Testing
- npm run lint *(fails: repository has pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cfce374920832094818d6291cf9ce8